### PR TITLE
Add timing results from Mac Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,25 +15,23 @@ NOTE: linux missing due to unavailability of compiler
 
 # Results
 
-Win32 and Win64 tests run on a Macbook 2014 using VMWare Fusion.
-iPhone 6s 64bit
-Cubot J7 Android 9 32bit
+Samples: 1,000,000
 
-Samples 1 000 000
+Digits: 10,000,000
 
-Digits: 10 000 000 
-
-for n digits, iteration count of log2 n is used.
+For n digits, iteration count of log2 n is used.
 
 *Release Build*
 
-|Platform| Timing  | 
-|---|---|
-| Win32 |  867ms |  
-| Win64 |  763ms  | 
-| OSX | 1699ms |  
-| iOS |  6875ms | 
-| Android | 53850ms | 
+Test Device | Win32 | Win64 | macOS | iOS | Android
+---|---:|---:|---:|---:|---:
+MacBook 2014 | 867ms<sup>1</sup> | 763ms<sup>1</sup> | 1,699ms | - | -
+iPhone 6s 64bit | - | - | - | 6,875ms | -
+Cubot J7 Android 9 32bit | - | - | - | - | 53,850ms
+Mac Pro (Late 2013) 3GHz 8-Core Intel Xeon E5 | 781ms<sup>1</sup> | 656ms<sup>1</sup> | 1,404ms | - | -
+iPhone Xs | - | - | - | 4,748ms | -
+
+1. Running in VMWare Fusion
 
 # NOTE
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ For n digits, iteration count of log2 n is used.
 
 *Release Build*
 
-Test Device | Win32 | Win64 | macOS | iOS | Android
----|---:|---:|---:|---:|---:
-MacBook 2014 | 867ms<sup>1</sup> | 763ms<sup>1</sup> | 1,699ms | - | -
-iPhone 6s 64bit | - | - | - | 6,875ms | -
-Cubot J7 Android 9 32bit | - | - | - | - | 53,850ms
-Mac Pro (Late 2013) 3GHz 8-Core Intel Xeon E5 | 781ms<sup>1</sup> | 656ms<sup>1</sup> | 1,404ms | - | -
-iPhone Xs | - | - | - | 4,748ms | -
+Test Device | Delphi Version | Win32 | Win64 | macOS | iOS | Android
+---|---|---:|---:|---:|---:|---:
+MacBook 2014 | ? | 867ms<sup>1</sup> | 763ms<sup>1</sup> | 1,699ms | - | -
+iPhone 6s 64bit | ? | - | - | - | 6,875ms | -
+Cubot J7 Android 9 32bit | ? | - | - | - | - | 53,850ms
+Mac Pro (Late 2013) 3GHz 8-Core Intel Xeon E5 | 10.4 (p.3) | 781ms<sup>1</sup> | 656ms<sup>1</sup> | 1,404ms | - | -
+iPhone Xs | 10.4 (p.3) | - | - | - | 4,748ms | -
 
 1. Running in VMWare Fusion
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ For n digits, iteration count of log2 n is used.
 
 *Release Build*
 
-Test Device | Delphi Version | Win32 | Win64 | macOS | iOS | Android
----|---|---:|---:|---:|---:|---:
-MacBook 2014 | ? | 867ms<sup>1</sup> | 763ms<sup>1</sup> | 1,699ms | - | -
-iPhone 6s 64bit | ? | - | - | - | 6,875ms | -
-Cubot J7 Android 9 32bit | ? | - | - | - | - | 53,850ms
-Mac Pro (Late 2013) 3GHz 8-Core Intel Xeon E5 | 10.4 (p.3) | 781ms<sup>1</sup> | 656ms<sup>1</sup> | 1,404ms | - | -
-iPhone Xs | 10.4 (p.3) | - | - | - | 4,748ms | -
+Test Device | Delphi Version | Win32 | Win64 | macOS | iOS | Android | Linux
+---|---|---:|---:|---:|---:|---:|---:
+MacBook 2014 | ? | 867ms<sup>1</sup> | 763ms<sup>1</sup> | 1,699ms | - | - | -
+iPhone 6s 64bit | ? | - | - | - | 6,875ms | - | -
+Cubot J7 Android 9 32bit | ? | - | - | - | - | 53,850ms | -
+Mac Pro (Late 2013) 3GHz 8-Core Intel Xeon E5 | 10.4 (p.3) | 781ms<sup>1</sup> | 656ms<sup>1</sup> | 1,404ms | - | - | 8,358ms
+iPhone Xs | 10.4 (p.3) | - | - | - | 4,748ms | - | -
 
 1. Running in VMWare Fusion
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ For n digits, iteration count of log2 n is used.
 
 Test Device | Delphi Version | Win32 | Win64 | macOS | iOS | Android | Linux
 ---|---|---:|---:|---:|---:|---:|---:
-MacBook 2014 | ? | 867ms<sup>1</sup> | 763ms<sup>1</sup> | 1,699ms | - | - | -
-iPhone 6s 64bit | ? | - | - | - | 6,875ms | - | -
-Cubot J7 Android 9 32bit | ? | - | - | - | - | 53,850ms | -
+MacBook 2014 | 10.3.3 | 867ms<sup>1</sup> | 763ms<sup>1</sup> | 1,699ms | - | - | -
+iPhone 6s 64bit | 10.3.3 | - | - | - | 6,875ms | - | -
+Cubot J7 Android 9 32bit | 10.3.3 | - | - | - | - | 53,850ms | -
 Mac Pro (Late 2013) 3GHz 8-Core Intel Xeon E5 | 10.4 (p.3) | 781ms<sup>1</sup> | 656ms<sup>1</sup> | 1,404ms | - | - | 8,358ms
 iPhone Xs | 10.4 (p.3) | - | - | - | 4,748ms | - | -
 


### PR DESCRIPTION
I have also re-organized the table of results to allow multiple devices and configurations.