### PR TITLE
update timing to review diff between extended and double on same test

### DIFF
--- a/FormGaussLegendrePIApproximation.fmx
+++ b/FormGaussLegendrePIApproximation.fmx
@@ -9,22 +9,22 @@ object TGaussLegendrePIApproximationForm: TTGaussLegendrePIApproximationForm
   FormFactor.Devices = [Desktop]
   OnCreate = FormCreate
   DesignerMasterStyle = 0
-  object lblTimingMSValue: TLabel
+  object lblTimingMSValueD: TLabel
     Position.X = 208.000000000000000000
     Position.Y = 104.000000000000000000
     Text = '(pending)'
-    TabOrder = 0
+    TabOrder = 1
   end
   object butCalculate: TButton
     Position.X = 208.000000000000000000
     Position.Y = 224.000000000000000000
-    TabOrder = 1
+    TabOrder = 2
     Text = 'Calculate'
     OnClick = butCalculateClick
   end
   object edtDigits: TNumberBox
     Touch.InteractiveGestures = [LongTap, DoubleTap]
-    TabOrder = 3
+    TabOrder = 4
     Cursor = crIBeam
     Max = 99999997952.000000000000000000
     Value = 10000000.000000000000000000
@@ -33,7 +33,7 @@ object TGaussLegendrePIApproximationForm: TTGaussLegendrePIApproximationForm
   end
   object edtSamples: TNumberBox
     Touch.InteractiveGestures = [LongTap, DoubleTap]
-    TabOrder = 2
+    TabOrder = 3
     Cursor = crIBeam
     Max = 99999997952.000000000000000000
     Value = 1000000.000000000000000000
@@ -43,17 +43,17 @@ object TGaussLegendrePIApproximationForm: TTGaussLegendrePIApproximationForm
   object lblTimingMS: TLabel
     Position.X = 24.000000000000000000
     Position.Y = 104.000000000000000000
-    Size.Width = 329.000000000000000000
+    Size.Width = 185.000000000000000000
     Size.Height = 17.000000000000000000
     Size.PlatformDefault = False
     Text = 'Total Time (ms)'
-    TabOrder = 4
+    TabOrder = 5
   end
   object lblSamples: TLabel
     Position.X = 24.000000000000000000
     Position.Y = 24.000000000000000000
     Text = 'Samples'
-    TabOrder = 5
+    TabOrder = 6
   end
   object lblDigits: TLabel
     Position.X = 24.000000000000000000
@@ -62,7 +62,7 @@ object TGaussLegendrePIApproximationForm: TTGaussLegendrePIApproximationForm
     Size.Height = 17.000000000000000000
     Size.PlatformDefault = False
     Text = 'Digits'
-    TabOrder = 6
+    TabOrder = 7
   end
   object lblApproximation: TLabel
     Position.X = 24.000000000000000000
@@ -71,7 +71,7 @@ object TGaussLegendrePIApproximationForm: TTGaussLegendrePIApproximationForm
     Size.Height = 17.000000000000000000
     Size.PlatformDefault = False
     Text = 'Approximation'
-    TabOrder = 7
+    TabOrder = 8
   end
   object lblApproximationValue: TLabel
     AutoSize = True
@@ -81,18 +81,24 @@ object TGaussLegendrePIApproximationForm: TTGaussLegendrePIApproximationForm
     Size.Height = 16.000000000000000000
     Size.PlatformDefault = False
     Text = '(pending)'
-    TabOrder = 8
+    TabOrder = 9
   end
   object lblPlatform: TLabel
     Position.X = 24.000000000000000000
     Position.Y = 184.000000000000000000
     Text = 'Platform'
-    TabOrder = 9
+    TabOrder = 10
   end
   object lblPlatformValue: TLabel
     Position.X = 208.000000000000000000
     Position.Y = 184.000000000000000000
     Text = 'lblPlatformValue'
-    TabOrder = 10
+    TabOrder = 11
+  end
+  object lblTimingMSValueE: TLabel
+    Position.X = 296.000000000000000000
+    Position.Y = 104.000000000000000000
+    Text = '(pending)'
+    TabOrder = 0
   end
 end

--- a/FormGaussLegendrePIApproximation.pas
+++ b/FormGaussLegendrePIApproximation.pas
@@ -10,7 +10,7 @@ uses
 
 type
   TTGaussLegendrePIApproximationForm = class(TForm)
-    lblTimingMSValue: TLabel;
+    lblTimingMSValueD: TLabel;
     butCalculate: TButton;
     edtDigits: TNumberBox;
     edtSamples: TNumberBox;
@@ -21,6 +21,7 @@ type
     lblApproximationValue: TLabel;
     lblPlatform: TLabel;
     lblPlatformValue: TLabel;
+    lblTimingMSValueE: TLabel;
     procedure butCalculateClick(Sender: TObject);
     procedure FormCreate(Sender: TObject);
   private
@@ -38,28 +39,39 @@ implementation
 
 uses
   System.Math,
+  utils,
   gauss.legendre.pi;
 
 procedure TTGaussLegendrePIApproximationForm.butCalculateClick(Sender: TObject);
 var
-  i, deltaMS, iterations, samples: integer;
+  i, iterations, samples: integer;
   startime, endtime: tdatetime;
   approx: double;
 begin
   butCalculate.Enabled := false;
-  lblTimingMSValue.Text := '(pending)';
+  lblTimingMSValueE.Text := '(pending)';
+  lblTimingMSValueD.Text := '(pending)';
   lblApproximationValue.Text := '(pending)';
   samples := trunc(edtSamples.Value);
   iterations := trunc(Log2(edtDigits.Value));
+
+  // using Extended
   startime := now;
   for i := 1 to samples do
-    approx := approximatePI(iterations);
+    approx := approximatePIE(iterations);
   endtime := now;
   lblApproximationValue.Text := FloatToStr(approx);
-  deltaMS := trunc(TimeStampToMSecs(DateTimeToTimeStamp(endtime)) -
-    TimeStampToMSecs(DateTimeToTimeStamp(startime)));
 
-  lblTimingMSValue.Text := FloatToStr(deltaMS);
+  lblTimingMSValueE.Text := FloatToStr(millisecondDiff(startime, endtime));
+
+  // using double
+  startime := now;
+  for i := 1 to samples do
+    approx := approximatePID(iterations);
+  endtime := now;
+
+  lblTimingMSValueD.Text := FloatToStr(millisecondDiff(startime, endtime));
+
   butCalculate.Enabled := true;
 end;
 

--- a/GaussLegendrePIApproximation.deployproj
+++ b/GaussLegendrePIApproximation.deployproj
@@ -6,7 +6,7 @@
     <PropertyGroup>
         <DeviceId Condition="'$(Platform)'=='Android'">E553XXCM99170002</DeviceId>
         <DeviceId Condition="'$(Platform)'=='Android64'"/>
-        <DeviceId Condition="'$(Platform)'=='iOSDevice64'"/>
+        <DeviceId Condition="'$(Platform)'=='iOSDevice64'">b3cad110b2584379071a1ccbcd458d7b19526506</DeviceId>
         <DeviceId Condition="'$(Platform)'=='iOSSimulator'"/>
     </PropertyGroup>
     <ItemGroup Condition="'$(Platform)'=='iOSDevice64'">
@@ -23,6 +23,15 @@
             <RemoteDir>GaussLegendrePIApproximation.app\</RemoteDir>
             <RemoteName>FM_ApplicationIcon_57x57.png</RemoteName>
             <DeployClass>iPhone_AppIcon57</DeployClass>
+            <Operation>0</Operation>
+            <LocalCommand/>
+            <RemoteCommand/>
+            <Overwrite>True</Overwrite>
+        </DeployFile>
+        <DeployFile Include="$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_180x180.png" Condition="'$(Config)'=='Release'">
+            <RemoteDir>GaussLegendrePIApproximation.app\</RemoteDir>
+            <RemoteName>FM_ApplicationIcon_180x180.png</RemoteName>
+            <DeployClass>iPhone_AppIcon180</DeployClass>
             <Operation>0</Operation>
             <LocalCommand/>
             <RemoteCommand/>
@@ -50,15 +59,6 @@
             <RemoteDir>GaussLegendrePIApproximation.app\</RemoteDir>
             <RemoteName>FM_ApplicationIcon_57x57.png</RemoteName>
             <DeployClass>iPhone_AppIcon57</DeployClass>
-            <Operation>0</Operation>
-            <LocalCommand/>
-            <RemoteCommand/>
-            <Overwrite>True</Overwrite>
-        </DeployFile>
-        <DeployFile Include="$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_180x180.png" Condition="'$(Config)'=='Release'">
-            <RemoteDir>GaussLegendrePIApproximation.app\</RemoteDir>
-            <RemoteName>FM_ApplicationIcon_180x180.png</RemoteName>
-            <DeployClass>iPhone_AppIcon180</DeployClass>
             <Operation>0</Operation>
             <LocalCommand/>
             <RemoteCommand/>
@@ -181,15 +181,6 @@
             <RemoteCommand/>
             <Overwrite>True</Overwrite>
         </DeployFile>
-        <DeployFile Include="$(BDS)\bin\Artwork\iOS\iPhone\FM_LaunchImage_1334x750.png" Condition="'$(Config)'=='Debug'">
-            <RemoteDir>GaussLegendrePIApproximation.app\</RemoteDir>
-            <RemoteName>Default-Landscape-750w-1334h@2x.png</RemoteName>
-            <DeployClass>iPhone_Launch1334</DeployClass>
-            <Operation>1</Operation>
-            <LocalCommand/>
-            <RemoteCommand/>
-            <Overwrite>True</Overwrite>
-        </DeployFile>
         <DeployFile Include="$(BDS)\bin\Artwork\iOS\iPad\FM_ApplicationIcon_144x144.png" Condition="'$(Config)'=='Release'">
             <RemoteDir>GaussLegendrePIApproximation.app\</RemoteDir>
             <RemoteName>FM_ApplicationIcon_144x144.png</RemoteName>
@@ -204,6 +195,15 @@
             <RemoteName>FM_SpotlightSearchIcon_40x40.png</RemoteName>
             <DeployClass>iPhone_Spotlight40</DeployClass>
             <Operation>0</Operation>
+            <LocalCommand/>
+            <RemoteCommand/>
+            <Overwrite>True</Overwrite>
+        </DeployFile>
+        <DeployFile Include="$(BDS)\bin\Artwork\iOS\iPhone\FM_LaunchImage_1334x750.png" Condition="'$(Config)'=='Debug'">
+            <RemoteDir>GaussLegendrePIApproximation.app\</RemoteDir>
+            <RemoteName>Default-Landscape-750w-1334h@2x.png</RemoteName>
+            <DeployClass>iPhone_Launch1334</DeployClass>
+            <Operation>1</Operation>
             <LocalCommand/>
             <RemoteCommand/>
             <Overwrite>True</Overwrite>
@@ -932,6 +932,7 @@
         </DeployFile>
     </ItemGroup>
     <ItemGroup Condition="'$(Platform)'=='Win64'"/>
+    <ItemGroup Condition="'$(Platform)'=='iOSDevice32'"/>
     <ItemGroup Condition="'$(Platform)'=='Win32'">
         <DeployFile Include="Win32\Debug\GaussLegendrePIApproximation.exe" Condition="'$(Config)'=='Debug'">
             <RemoteDir>GaussLegendrePIApproximation\</RemoteDir>
@@ -943,30 +944,19 @@
             <Overwrite>True</Overwrite>
             <Required>True</Required>
         </DeployFile>
-    </ItemGroup>
-    <ItemGroup Condition="'$(Platform)'=='Linux64'">
-        <DeployFile Include="Linux64\Release\GaussLegendrePIApproximation" Condition="'$(Config)'=='Release'">
+        <DeployFile Include="Win32\Release\GaussLegendrePIApproximation.exe" Condition="'$(Config)'=='Release'">
             <RemoteDir>GaussLegendrePIApproximation\</RemoteDir>
-            <RemoteName>GaussLegendrePIApproximation</RemoteName>
+            <RemoteName>GaussLegendrePIApproximation.exe</RemoteName>
             <DeployClass>ProjectOutput</DeployClass>
-            <Operation>1</Operation>
+            <Operation>0</Operation>
             <LocalCommand/>
             <RemoteCommand/>
             <Overwrite>True</Overwrite>
             <Required>True</Required>
         </DeployFile>
     </ItemGroup>
-    <ItemGroup Condition="'$(Platform)'=='OSX64'">
-        <DeployFile Include="OSX64\Debug\GaussLegendrePIApproximation.entitlements" Condition="'$(Config)'=='Debug'">
-            <RemoteDir>GaussLegendrePIApproximation.app\..\</RemoteDir>
-            <RemoteName>GaussLegendrePIApproximation.entitlements</RemoteName>
-            <DeployClass>ProjectOSXEntitlements</DeployClass>
-            <Operation>1</Operation>
-            <LocalCommand/>
-            <RemoteCommand/>
-            <Overwrite>True</Overwrite>
-        </DeployFile>
-        <DeployFile Include="OSX64\Release\GaussLegendrePIApproximation.info.plist" Condition="'$(Config)'=='Release'">
+    <ItemGroup Condition="'$(Platform)'=='OSX32'">
+        <DeployFile Include="OSX32\Release\Project2.info.plist" Condition="'$(Config)'=='Release'">
             <RemoteDir>GaussLegendrePIApproximation.app\Contents\</RemoteDir>
             <RemoteName>Info.plist</RemoteName>
             <DeployClass>ProjectOSXInfoPList</DeployClass>
@@ -975,7 +965,16 @@
             <RemoteCommand/>
             <Overwrite>True</Overwrite>
         </DeployFile>
-        <DeployFile Include="OSX64\Release\GaussLegendrePIApproximation" Condition="'$(Config)'=='Release'">
+        <DeployFile Include="$(BDS)\Redist\osx32\libcgunwind.1.0.dylib">
+            <RemoteDir>GaussLegendrePIApproximation.app\Contents\MacOS\</RemoteDir>
+            <RemoteName>libcgunwind.1.0.dylib</RemoteName>
+            <DeployClass>DependencyModule</DeployClass>
+            <Operation>1</Operation>
+            <LocalCommand/>
+            <RemoteCommand/>
+            <Overwrite>True</Overwrite>
+        </DeployFile>
+        <DeployFile Include="OSX32\Release\GaussLegendrePIApproximation" Condition="'$(Config)'=='Release'">
             <RemoteDir>GaussLegendrePIApproximation.app\Contents\MacOS\</RemoteDir>
             <RemoteName>GaussLegendrePIApproximation</RemoteName>
             <DeployClass>ProjectOutput</DeployClass>
@@ -984,66 +983,20 @@
             <RemoteCommand/>
             <Overwrite>True</Overwrite>
             <Required>True</Required>
-        </DeployFile>
-        <DeployFile Include="OSX64\Debug\GaussLegendrePIApproximation.info.plist" Condition="'$(Config)'=='Debug'">
-            <RemoteDir>GaussLegendrePIApproximation.app\Contents\</RemoteDir>
-            <RemoteName>Info.plist</RemoteName>
-            <DeployClass>ProjectOSXInfoPList</DeployClass>
-            <Operation>1</Operation>
-            <LocalCommand/>
-            <RemoteCommand/>
-            <Overwrite>True</Overwrite>
-        </DeployFile>
-        <DeployFile Include="$(BDS)\bin\delphi_PROJECTICNS.icns" Condition="'$(Config)'=='Debug'">
-            <RemoteDir>GaussLegendrePIApproximation.app\Contents\Resources\</RemoteDir>
-            <RemoteName>GaussLegendrePIApproximation.icns</RemoteName>
-            <DeployClass>ProjectOSXResource</DeployClass>
-            <Operation>1</Operation>
-            <LocalCommand/>
-            <RemoteCommand/>
-            <Overwrite>True</Overwrite>
-        </DeployFile>
-        <DeployFile Include="OSX64\Release\GaussLegendrePIApproximation.dSYM" Condition="'$(Config)'=='Release'">
-            <RemoteDir>GaussLegendrePIApproximation.app\..\$(PROJECTNAME).app.dSYM\Contents\Resources\DWARF\</RemoteDir>
-            <RemoteName>GaussLegendrePIApproximation</RemoteName>
-            <DeployClass>ProjectOSXDebug</DeployClass>
-            <Operation>1</Operation>
-            <LocalCommand/>
-            <RemoteCommand/>
-            <Overwrite>True</Overwrite>
-        </DeployFile>
-        <DeployFile Include="OSX64\Release\GaussLegendrePIApproximation.entitlements" Condition="'$(Config)'=='Release'">
-            <RemoteDir>GaussLegendrePIApproximation.app\..\</RemoteDir>
-            <RemoteName>GaussLegendrePIApproximation.entitlements</RemoteName>
-            <DeployClass>ProjectOSXEntitlements</DeployClass>
-            <Operation>1</Operation>
-            <LocalCommand/>
-            <RemoteCommand/>
-            <Overwrite>True</Overwrite>
         </DeployFile>
         <DeployFile Include="$(BDS)\bin\delphi_PROJECTICNS.icns" Condition="'$(Config)'=='Release'">
             <RemoteDir>GaussLegendrePIApproximation.app\Contents\Resources\</RemoteDir>
-            <RemoteName>GaussLegendrePIApproximation.icns</RemoteName>
+            <RemoteName>Project2.icns</RemoteName>
             <DeployClass>ProjectOSXResource</DeployClass>
             <Operation>1</Operation>
             <LocalCommand/>
             <RemoteCommand/>
             <Overwrite>True</Overwrite>
         </DeployFile>
-        <DeployFile Include="OSX64\Debug\GaussLegendrePIApproximation" Condition="'$(Config)'=='Debug'">
-            <RemoteDir>GaussLegendrePIApproximation.app\Contents\MacOS\</RemoteDir>
-            <RemoteName>GaussLegendrePIApproximation</RemoteName>
-            <DeployClass>ProjectOutput</DeployClass>
-            <Operation>1</Operation>
-            <LocalCommand/>
-            <RemoteCommand/>
-            <Overwrite>True</Overwrite>
-            <Required>True</Required>
-        </DeployFile>
-        <DeployFile Include="OSX64\Debug\GaussLegendrePIApproximation.dSYM" Condition="'$(Config)'=='Debug'">
-            <RemoteDir>GaussLegendrePIApproximation.app\..\$(PROJECTNAME).app.dSYM\Contents\Resources\DWARF\</RemoteDir>
-            <RemoteName>GaussLegendrePIApproximation</RemoteName>
-            <DeployClass>ProjectOSXDebug</DeployClass>
+        <DeployFile Include="OSX32\Release\Project2.entitlements" Condition="'$(Config)'=='Release'">
+            <RemoteDir>GaussLegendrePIApproximation.app\..\</RemoteDir>
+            <RemoteName>Project2.entitlements</RemoteName>
+            <DeployClass>ProjectOSXEntitlements</DeployClass>
             <Operation>1</Operation>
             <LocalCommand/>
             <RemoteCommand/>
@@ -1150,6 +1103,15 @@
             <RemoteCommand/>
             <Overwrite>True</Overwrite>
         </DeployFile>
+        <DeployFile Include="$(BDS)\bin\Artwork\Android\FM_LauncherIcon_48x48.png" Condition="'$(Config)'=='Release'">
+            <RemoteDir>GaussLegendrePIApproximation\res\drawable-mdpi\</RemoteDir>
+            <RemoteName>ic_launcher.png</RemoteName>
+            <DeployClass>Android_LauncherIcon48</DeployClass>
+            <Operation>1</Operation>
+            <LocalCommand/>
+            <RemoteCommand/>
+            <Overwrite>True</Overwrite>
+        </DeployFile>
         <DeployFile Include="Android\Debug\strings.xml" Condition="'$(Config)'=='Debug'">
             <RemoteDir>GaussLegendrePIApproximation\res\values\</RemoteDir>
             <RemoteName>strings.xml</RemoteName>
@@ -1204,15 +1166,6 @@
             <RemoteCommand/>
             <Overwrite>True</Overwrite>
             <Required>True</Required>
-        </DeployFile>
-        <DeployFile Include="$(BDS)\bin\Artwork\Android\FM_LauncherIcon_48x48.png" Condition="'$(Config)'=='Release'">
-            <RemoteDir>GaussLegendrePIApproximation\res\drawable-mdpi\</RemoteDir>
-            <RemoteName>ic_launcher.png</RemoteName>
-            <DeployClass>Android_LauncherIcon48</DeployClass>
-            <Operation>1</Operation>
-            <LocalCommand/>
-            <RemoteCommand/>
-            <Overwrite>True</Overwrite>
         </DeployFile>
         <DeployFile Include="$(BDS)\bin\Artwork\Android\FM_SplashImage_640x480.png" Condition="'$(Config)'=='Debug'">
             <RemoteDir>GaussLegendrePIApproximation\res\drawable-large\</RemoteDir>
@@ -1480,6 +1433,100 @@
             <RemoteDir>GaussLegendrePIApproximation\res\drawable-normal\</RemoteDir>
             <RemoteName>splash_image.png</RemoteName>
             <DeployClass>Android_SplashImage470</DeployClass>
+            <Operation>1</Operation>
+            <LocalCommand/>
+            <RemoteCommand/>
+            <Overwrite>True</Overwrite>
+        </DeployFile>
+    </ItemGroup>
+    <ItemGroup Condition="'$(Platform)'=='OSX64'">
+        <DeployFile Include="OSX64\Debug\GaussLegendrePIApproximation.entitlements" Condition="'$(Config)'=='Debug'">
+            <RemoteDir>GaussLegendrePIApproximation.app\..\</RemoteDir>
+            <RemoteName>GaussLegendrePIApproximation.entitlements</RemoteName>
+            <DeployClass>ProjectOSXEntitlements</DeployClass>
+            <Operation>1</Operation>
+            <LocalCommand/>
+            <RemoteCommand/>
+            <Overwrite>True</Overwrite>
+        </DeployFile>
+        <DeployFile Include="OSX64\Release\GaussLegendrePIApproximation.info.plist" Condition="'$(Config)'=='Release'">
+            <RemoteDir>GaussLegendrePIApproximation.app\Contents\</RemoteDir>
+            <RemoteName>Info.plist</RemoteName>
+            <DeployClass>ProjectOSXInfoPList</DeployClass>
+            <Operation>1</Operation>
+            <LocalCommand/>
+            <RemoteCommand/>
+            <Overwrite>True</Overwrite>
+        </DeployFile>
+        <DeployFile Include="OSX64\Release\GaussLegendrePIApproximation" Condition="'$(Config)'=='Release'">
+            <RemoteDir>GaussLegendrePIApproximation.app\Contents\MacOS\</RemoteDir>
+            <RemoteName>GaussLegendrePIApproximation</RemoteName>
+            <DeployClass>ProjectOutput</DeployClass>
+            <Operation>1</Operation>
+            <LocalCommand/>
+            <RemoteCommand/>
+            <Overwrite>True</Overwrite>
+            <Required>True</Required>
+        </DeployFile>
+        <DeployFile Include="OSX64\Debug\GaussLegendrePIApproximation.info.plist" Condition="'$(Config)'=='Debug'">
+            <RemoteDir>GaussLegendrePIApproximation.app\Contents\</RemoteDir>
+            <RemoteName>Info.plist</RemoteName>
+            <DeployClass>ProjectOSXInfoPList</DeployClass>
+            <Operation>1</Operation>
+            <LocalCommand/>
+            <RemoteCommand/>
+            <Overwrite>True</Overwrite>
+        </DeployFile>
+        <DeployFile Include="$(BDS)\bin\delphi_PROJECTICNS.icns" Condition="'$(Config)'=='Debug'">
+            <RemoteDir>GaussLegendrePIApproximation.app\Contents\Resources\</RemoteDir>
+            <RemoteName>GaussLegendrePIApproximation.icns</RemoteName>
+            <DeployClass>ProjectOSXResource</DeployClass>
+            <Operation>1</Operation>
+            <LocalCommand/>
+            <RemoteCommand/>
+            <Overwrite>True</Overwrite>
+        </DeployFile>
+        <DeployFile Include="OSX64\Release\GaussLegendrePIApproximation.dSYM" Condition="'$(Config)'=='Release'">
+            <RemoteDir>GaussLegendrePIApproximation.app\..\$(PROJECTNAME).app.dSYM\Contents\Resources\DWARF\</RemoteDir>
+            <RemoteName>GaussLegendrePIApproximation</RemoteName>
+            <DeployClass>ProjectOSXDebug</DeployClass>
+            <Operation>1</Operation>
+            <LocalCommand/>
+            <RemoteCommand/>
+            <Overwrite>True</Overwrite>
+        </DeployFile>
+        <DeployFile Include="OSX64\Release\GaussLegendrePIApproximation.entitlements" Condition="'$(Config)'=='Release'">
+            <RemoteDir>GaussLegendrePIApproximation.app\..\</RemoteDir>
+            <RemoteName>GaussLegendrePIApproximation.entitlements</RemoteName>
+            <DeployClass>ProjectOSXEntitlements</DeployClass>
+            <Operation>1</Operation>
+            <LocalCommand/>
+            <RemoteCommand/>
+            <Overwrite>True</Overwrite>
+        </DeployFile>
+        <DeployFile Include="$(BDS)\bin\delphi_PROJECTICNS.icns" Condition="'$(Config)'=='Release'">
+            <RemoteDir>GaussLegendrePIApproximation.app\Contents\Resources\</RemoteDir>
+            <RemoteName>GaussLegendrePIApproximation.icns</RemoteName>
+            <DeployClass>ProjectOSXResource</DeployClass>
+            <Operation>1</Operation>
+            <LocalCommand/>
+            <RemoteCommand/>
+            <Overwrite>True</Overwrite>
+        </DeployFile>
+        <DeployFile Include="OSX64\Debug\GaussLegendrePIApproximation" Condition="'$(Config)'=='Debug'">
+            <RemoteDir>GaussLegendrePIApproximation.app\Contents\MacOS\</RemoteDir>
+            <RemoteName>GaussLegendrePIApproximation</RemoteName>
+            <DeployClass>ProjectOutput</DeployClass>
+            <Operation>1</Operation>
+            <LocalCommand/>
+            <RemoteCommand/>
+            <Overwrite>True</Overwrite>
+            <Required>True</Required>
+        </DeployFile>
+        <DeployFile Include="OSX64\Debug\GaussLegendrePIApproximation.dSYM" Condition="'$(Config)'=='Debug'">
+            <RemoteDir>GaussLegendrePIApproximation.app\..\$(PROJECTNAME).app.dSYM\Contents\Resources\DWARF\</RemoteDir>
+            <RemoteName>GaussLegendrePIApproximation</RemoteName>
+            <DeployClass>ProjectOSXDebug</DeployClass>
             <Operation>1</Operation>
             <LocalCommand/>
             <RemoteCommand/>

--- a/GaussLegendrePIApproximation.dpr
+++ b/GaussLegendrePIApproximation.dpr
@@ -4,7 +4,8 @@ uses
   System.StartUpCopy,
   FMX.Forms,
   FormGaussLegendrePIApproximation in 'FormGaussLegendrePIApproximation.pas' {TGaussLegendrePIApproximationForm},
-  gauss.legendre.pi in 'gauss.legendre.pi.pas';
+  gauss.legendre.pi in 'gauss.legendre.pi.pas',
+  utils in 'utils.pas';
 
 {$R *.res}
 

--- a/GaussLegendrePIApproximation.dproj
+++ b/GaussLegendrePIApproximation.dproj
@@ -6,8 +6,8 @@
         <MainSource>GaussLegendrePIApproximation.dpr</MainSource>
         <Base>True</Base>
         <Config Condition="'$(Config)'==''">Release</Config>
-        <Platform Condition="'$(Platform)'==''">Linux64</Platform>
-        <TargetedPlatforms>5267</TargetedPlatforms>
+        <Platform Condition="'$(Platform)'==''">iOSDevice64</Platform>
+        <TargetedPlatforms>5139</TargetedPlatforms>
         <AppType>Application</AppType>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
@@ -377,6 +377,7 @@
             <FormType>fmx</FormType>
         </DCCReference>
         <DCCReference Include="gauss.legendre.pi.pas"/>
+        <DCCReference Include="utils.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>
@@ -690,9 +691,9 @@
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
-                <DeployFile LocalName="$(BDS)\lib\android\debug\armeabi\libnative-activity.so" Configuration="Release" Class="AndroidLibnativeArmeabiFile">
-                    <Platform Name="Android">
-                        <RemoteName>libGaussLegendrePIApproximation.so</RemoteName>
+                <DeployFile LocalName="Win32\Release\GaussLegendrePIApproximation.exe" Configuration="Release" Class="ProjectOutput">
+                    <Platform Name="Win32">
+                        <RemoteName>GaussLegendrePIApproximation.exe</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -715,6 +716,12 @@
                 </DeployFile>
                 <DeployFile LocalName="$(BDS)\bin\Artwork\iOS\iPad\FM_ApplicationIcon_76x76.png" Configuration="Debug" Class="iPad_AppIcon76">
                     <Platform Name="iOSDevice64">
+                        <Overwrite>true</Overwrite>
+                    </Platform>
+                </DeployFile>
+                <DeployFile LocalName="$(BDS)\lib\android\debug\armeabi\libnative-activity.so" Configuration="Release" Class="AndroidLibnativeArmeabiFile">
+                    <Platform Name="Android">
+                        <RemoteName>libGaussLegendrePIApproximation.so</RemoteName>
                         <Overwrite>true</Overwrite>
                     </Platform>
                 </DeployFile>
@@ -2260,7 +2267,6 @@
                 <Platform value="Android64">False</Platform>
                 <Platform value="iOSDevice64">True</Platform>
                 <Platform value="iOSSimulator">False</Platform>
-                <Platform value="Linux64">True</Platform>
                 <Platform value="OSX64">True</Platform>
                 <Platform value="Win32">True</Platform>
                 <Platform value="Win64">True</Platform>

--- a/README.md
+++ b/README.md
@@ -23,16 +23,20 @@ For n digits, iteration count of log2 n is used.
 
 *Timing Results*
 
-Tester | Test Device | Delphi Version | Win32 | Win64 | macOS | iOS | Android | Linux
----|---|---|---:|---:|---:|---:|---:|---:
-CV |MacBook Pro (Mid 2014) 3 GHz Dual-Core Intel Core i7 | 10.3.3 | 623ms<sup>1</sup> | 234ms<sup>1</sup> | 1,287ms | - | - | -
-CV |MacBook Pro (Mid 2014) 3 GHz Dual-Core Intel Core i7 | 10.4 (p.3) | 625ms<sup>1</sup> | 218ms<sup>1</sup> | 1,121ms | - | - | 9,364ms<sup>1</sup>
-CV |iPhone 6s 64bit | 10.3.3 | - | - | - | 5,888ms | - | -
-CV |iPhone 6s 64bit | 10.4 (p.3) | - | - | - | 5,847ms | - | -
-CV |Cubot J7 Android 9 32bit | 10.3.3 | - | - | - | - | 20,832ms | -
-CV |Cubot J7 Android 9 32bit | 10.4 (p.3) | - | - | - | - | 19,103ms | -
-RH |Mac Pro (Late 2013) 3GHz 8-Core Intel Xeon E5 | 10.4 (p.3) | 579ms<sup>1</sup> | 217ms<sup>1</sup> | 931ms | - | - | 8,288ms<sup>1</sup>
-RH |iPhone Xs | 10.4 (p.3) | - | - | - | 4,204ms | - | -
+Tester| Type  | Test Device | Delphi Version | Win32 | Win64 | macOS | iOS | Android | Linux
+---|---|---|---|---:|---:|---:|---:|---:|---:
+CV |Double |MacBook Pro (Mid 2014) 3 GHz Dual-Core Intel Core i7 | 10.3.3 | 531ms<sup>1</sup> | 234ms<sup>1</sup> | 865ms | - | - | -
+CV |Extended|MacBook Pro (Mid 2014) 3 GHz Dual-Core Intel Core i7 | 10.3.3 | 640ms<sup>1</sup> | 234ms<sup>1</sup> | 1,043ms | - | - | -
+CV |Double|iPhone 6s 64bit | 10.3.3 | - | - | - | 5,877ms | - | -
+CV |Extended|iPhone 6s 64bit | 10.3.3 | - | - | - | 5,966ms | - | -
+CV |Double|iPhone 6s 64bit | 10.4 (p.3) | - | - | - | 5,847ms | - | -
+CV |Extended|iPhone 6s 64bit | 10.4 (p.3) | - | - | - | 5,847ms | - | -
+CV |Double|Cubot J7 Android 9 32bit | 10.3.3 | - | - | - | - | 20,760ms | -
+CV |Extended|Cubot J7 Android 9 32bit | 10.3.3 | - | - | - | - | 20,771ms | -
+CV |Double|Cubot J7 Android 9 32bit | 10.4 (p.3) | - | - | - | - | 19,103ms | -
+CV |Extended|Cubot J7 Android 9 32bit | 10.4 (p.3) | - | - | - | - | 19,103ms | -
+RH |Extended|Mac Pro (Late 2013) 3GHz 8-Core Intel Xeon E5 | 10.4 (p.3) | 579ms<sup>1</sup> | 217ms<sup>1</sup> | 931ms | - | - | 8,288ms<sup>1</sup>
+RH |Extended|iPhone Xs | 10.4 (p.3) | - | - | - | 4,204ms | - | -
 
 1. Running in VMWare Fusion
 

--- a/gauss.legendre.pi.pas
+++ b/gauss.legendre.pi.pas
@@ -2,36 +2,52 @@ unit gauss.legendre.pi;
 
 interface
 
-type
-  // type used to change quickly between double or extended
-  // TFloat = double;
-  TFloat = extended;
-
-function approximatePI(iterations: integer): TFloat;
+function approximatePIe(iterations: integer): Extended;
+function approximatePId(iterations: integer): double;
 
 implementation
 
 uses
   System.Math;
 
-function approximatePI(iterations: integer): TFloat;
+function approximatePId(iterations: integer): double;
 var
-  a, b, t, x, y: TFloat;
+  a, b, T, x, y: double;
 begin
   a := 1;
   b := 1 / Sqrt(2.0);
-  t := 1 / 4;
+  T := 1 / 4;
   x := 1;
   while iterations > 0 do
   begin
     y := a;
     a := (a + b) / 2;
     b := Sqrt(b * y);
-    t := t - x * intpower(y - a, 2);
+    T := T - x * intpower(y - a, 2);
     x := 2 * x;
     dec(iterations);
   end;
-  result := power(a + b, 2) / (4 * t);
+  result := power(a + b, 2) / (4 * T);
+end;
+
+function approximatePIe(iterations: integer): Extended;
+var
+  a, b, T, x, y: Extended;
+begin
+  a := 1;
+  b := 1 / Sqrt(2.0);
+  T := 1 / 4;
+  x := 1;
+  while iterations > 0 do
+  begin
+    y := a;
+    a := (a + b) / 2;
+    b := Sqrt(b * y);
+    T := T - x * intpower(y - a, 2);
+    x := 2 * x;
+    dec(iterations);
+  end;
+  result := power(a + b, 2) / (4 * T);
 end;
 
 end.

--- a/utils.pas
+++ b/utils.pas
@@ -1,0 +1,17 @@
+unit utils;
+
+interface
+
+uses
+  System.SysUtils;
+
+function millisecondDiff(const AStart, AEnd: TDateTime): int64;
+
+implementation
+
+function millisecondDiff(const AStart, AEnd: TDateTime): int64;
+begin
+  result := trunc(TimeStampToMSecs(DateTimeToTimeStamp(AEnd)) - TimeStampToMSecs(DateTimeToTimeStamp(AStart)))
+end;
+
+end.


### PR DESCRIPTION
updates done for 10.3.3 with split of extended vs double. Couldn't use generics (generics in delphi don't work like C++ unfortunately) as math operations on an unknown T are not allowed.